### PR TITLE
Add assertion

### DIFF
--- a/src/main/java/nollid/javafx/Main.java
+++ b/src/main/java/nollid/javafx/Main.java
@@ -28,6 +28,7 @@ public class Main extends Application {
             AnchorPane ap = fxmlLoader.load();
             Scene scene = new Scene(ap);
             stage.setScene(scene);
+            assert nollid != null : "nollid instance should not be null";
             fxmlLoader.<MainWindow>getController().setNollid(nollid);
 
             stage.setTitle("Nollid");


### PR DESCRIPTION
Starting the GUI assumes that the Nollid object has been successfully instantiated.

Future changes to the code may break that assumption.

Let's add an assertion to ensure that the Nollid object is not null before starting the GUI.